### PR TITLE
Implement decoding factor graph state to spin values

### DIFF
--- a/src/factor.jl
+++ b/src/factor.jl
@@ -1,4 +1,4 @@
-export factor_graph, rank_reveal, projectors, split_into_clusters
+export factor_graph, rank_reveal, projectors, split_into_clusters, decode_factor_graph_state
 
 
 function split_into_clusters(ig::LabelledGraph{S, T}, assignment_rule) where {S, T}
@@ -90,4 +90,14 @@ function rank_reveal(energy, order=:PE)
     end
 
     order == :PE ? (P, E) : (E, P)
+end
+
+
+function decode_factor_graph_state(fg, state::Vector{Int})
+    all_spins = vcat([vertices(get_prop(fg, v, :cluster)) for v ∈ vertices(fg)]...)
+    spin_perm = sortperm(all_spins)
+
+    vcat(
+        [get_prop(fg, v, :spectrum).states[i] for (i, v) ∈ zip(state, vertices(fg))]...
+    )[spin_perm]
 end

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -174,3 +174,30 @@ end
    @test E * Pr ≈ E_old
    @test Pl * E * Pr ≈ energy
 end
+
+
+function create_example_factor_graph()
+   J12 = -1.0
+   h1 = 0.5
+   h2 = 0.75
+
+   
+   D = Dict((1, 2) => J12, (1, 1) => h1, (2, 2) => h2)
+   ig = ising_graph(D)
+
+   factor_graph(
+      ig,
+      Dict((1, 1) => 2, (1, 2) => 2),
+      spectrum = full_spectrum,
+      cluster_assignment_rule = Dict(1 => (1, 1), 2 => (1, 2)),
+  )
+end
+
+const fg_state_to_spin = [
+   ([1, 1], [-1, -1]), ([1, 2], [-1, 1]), ([2, 1], [1, -1]), ([2, 2], [1, 1])
+]
+
+@testset "Test decoding solution $(state) to spins gives $(spin_values) results" for (state, spin_values) ∈ fg_state_to_spin
+   fg = create_example_factor_graph()
+   @test decode_factor_graph_state(fg, state) == spin_values
+end


### PR DESCRIPTION
This implements decoding state given as factor graph configuration to the actual configuration of spins of the underlying Ising spinglass instance.
Included are two tests checking the correctness of the decoding function:
- simplest instance with two trivial clusters
- more complicated instance with four clusters with a varying number of spins in each cluster (this test compares energies only, but given that the instance is nontrivial it should suffice).