### PR TITLE
updated dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
-          - '1.8'
+          - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,3 +35,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
+          flag-name: job-${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpinGlassNetworks"
 uuid = "b7f6bd3e-55dc-4da6-96a9-ef9dbec6ac19"
 authors = ["Krzysztof Domino <kdomino@iitis.pl>", "Anna Maria Dziubyna <annamariadziubyna@gmail.com>", "Bartłomiej Gardas <bartek.gardas@gmail.com>", "Konrad Jałowiecki <dexter2206@gmail.com>", "Łukasz Pawela <lukasz.pawela@gmail.com>", "Marek M. Rams <marekrams@gmail.com>"]
-version = "0.3.1"
+version = "0.3.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -15,7 +15,7 @@ MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 CSV = "0.8"
 DocStringExtensions = "0.8"
 LabelledGraphs = "^0.4.4"
-julia = "1.7, 1.8, 1.9, 1.10"
+julia = "1.9, 1.10"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/Project.toml
+++ b/Project.toml
@@ -6,18 +6,16 @@ version = "0.3.0"
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LabelledGraphs = "605abd48-4d17-4660-b914-d4df33194460"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 
 [compat]
 CSV = "0.8"
 DocStringExtensions = "0.8"
-LabelledGraphs = "0.3.2"
-LightGraphs = "1.3"
-MetaGraphs = "0.6"
-julia = "1.7, 1.8"
+LabelledGraphs = "0.4.4"
+julia = "1.7, 1.8, 1.9, 1.10"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpinGlassNetworks"
 uuid = "b7f6bd3e-55dc-4da6-96a9-ef9dbec6ac19"
 authors = ["Krzysztof Domino <kdomino@iitis.pl>", "Anna Maria Dziubyna <annamariadziubyna@gmail.com>", "Bartłomiej Gardas <bartek.gardas@gmail.com>", "Konrad Jałowiecki <dexter2206@gmail.com>", "Łukasz Pawela <lukasz.pawela@gmail.com>", "Marek M. Rams <marekrams@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -14,7 +14,7 @@ MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 [compat]
 CSV = "0.8"
 DocStringExtensions = "0.8"
-LabelledGraphs = "0.4.4"
+LabelledGraphs = "^0.4.4"
 julia = "1.7, 1.8, 1.9, 1.10"
 
 [extras]

--- a/src/SpinGlassNetworks.jl
+++ b/src/SpinGlassNetworks.jl
@@ -1,6 +1,6 @@
 module SpinGlassNetworks
 using LabelledGraphs
-using LightGraphs
+using Graphs
 using MetaGraphs # TODO: remove that
 using CSV
 using DocStringExtensions

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -1,5 +1,5 @@
 using MetaGraphs
-using LightGraphs
+using Graphs
 using CSV
 
 enum(vec) = Dict(v => i for (i, v) ∈ enumerate(vec))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SpinGlassNetworks
 using LabelledGraphs
-using LightGraphs
+using Graphs
 using MetaGraphs
 using Logging
 using Test


### PR DESCRIPTION
LightGraphs.jl is deprecated and Graph.jl should be used instead.

- Updated LabelledGraphs dependency to a version free of the LightGraphs.jl dependency.
- Removed LightGraphs.jl dependency in this project.