### PR TITLE
Fix outdated CSV compat requirement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 
 [compat]
-CSV = "0.8"
+CSV = "≥ 0.8"
 DocStringExtensions = "0.8"
 Graphs = "1.9"
 LabelledGraphs = "^0.4.4"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 
 [compat]
-CSV = "≥ 0.8"
+CSV = "0.8 - 0.10"
 DocStringExtensions = "0.8"
 Graphs = "1.9"
 LabelledGraphs = "^0.4.4"


### PR DESCRIPTION
Forced `CSV` version resulted in chain dependencies (outdated `DataFrames`, broken `CUDA.@profile`) in any project that would use this one.

Allowing the upgrade seems inconsequential otherwise, tests still pass.